### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    core-client (0.2.2)
-      activesupport (= 6.0.3.1)
+    core-client (0.2.3)
+      activesupport (~> 6.0.3, >= 6.0.3.1)
       dotenv (~> 2.7)
       json_api_client (~> 1.16)
       rack (~> 2.2)

--- a/lib/core/client/version.rb
+++ b/lib/core/client/version.rb
@@ -1,5 +1,5 @@
 module Core
   module Client
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
Allow newer patches in the same minor release family for activesupport (= 6.0.3.4) (#9)

Note: I didn't test but assume it's fine given that it's a patch release. Specs were not passing on my machine (assuming it's unrelated).